### PR TITLE
Tile images

### DIFF
--- a/_sass/jekyll-theme-haymarket.scss
+++ b/_sass/jekyll-theme-haymarket.scss
@@ -881,8 +881,6 @@ a,
 
   .tile-container-image,
   .tile-container-text {
-    height: 15rem;
-
     .column-fix {
       position: absolute;
       top: 0;
@@ -911,6 +909,8 @@ a,
   }
 
   .tile-container-image {
+    height: 15rem;
+
     .image .overlay {
       position: absolute;
       width: 100%;
@@ -935,6 +935,8 @@ a,
   }
 
   .tile-container-text {
+    height: 2rem;
+
     .color-background {
       background-color: $dsa-purple;
 

--- a/_sass/jekyll-theme-haymarket.scss
+++ b/_sass/jekyll-theme-haymarket.scss
@@ -935,7 +935,7 @@ a,
   }
 
   .tile-container-text {
-    height: 2rem;
+    height: 3rem;
 
     .color-background {
       background-color: $dsa-purple;

--- a/_sass/jekyll-theme-haymarket.scss
+++ b/_sass/jekyll-theme-haymarket.scss
@@ -935,7 +935,7 @@ a,
   }
 
   .tile-container-text {
-    height: 3rem;
+    height: 3.25rem;
 
     .color-background {
       background-color: $dsa-purple;


### PR DESCRIPTION
This fixes some ugliness around tile images:
---
<img width="878" alt="Screen Shot 2021-07-06 at 6 23 48 PM" src="https://user-images.githubusercontent.com/5639575/124678174-9b286880-de87-11eb-86d6-29d25553b91b.png">

When we don't have images for the tiles, they still take up the default amount of space (15x root elem). I changed this to only apply for images, and then text-only tiles will be 3x root elem:

<img width="795" alt="Screen Shot 2021-07-06 at 6 19 57 PM" src="https://user-images.githubusercontent.com/5639575/124678259-c448f900-de87-11eb-984b-9cbcc788572a.png">

The other places we use tiles seem to be working fine with this change (campaigns, working groups, and branches) for both desktop and mobile.

Not sure what the process is for doing the version bump, let me know, would like to reference the new version in CDSA website
